### PR TITLE
mosaicsのquantityをfloatでも渡せるようにしました

### DIFF
--- a/lib/nem/transaction/transfer.rb
+++ b/lib/nem/transaction/transfer.rb
@@ -60,7 +60,7 @@ module Nem
                 namespaceId: moa.mosaic_id.namespace_id,
                 name: moa.mosaic_id.name,
               },
-              quantity: moa.amount
+              quantity: moa.amount.to_i
             }
           end
         end


### PR DESCRIPTION
floatを渡すとserializerでエラーになるのでNem::Transaction::Transfer#to_hashの時点でto_iするようにしました

```
/usr/local/bundle/gems/nem-ruby-0.0.10/lib/nem/util/serializer.rb:168:in `block in serialize_long': undefined method `>>' for 100000.0:Float
```