### PR TITLE
update dependency digest-sha3 -> digest-sha3-patched

### DIFF
--- a/nem-ruby.gemspec
+++ b/nem-ruby.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 2.3'
   spec.add_development_dependency 'pry-byebug', '~> 3'
 
-  spec.add_dependency 'digest-sha3', '~> 1.1'
+  spec.add_dependency 'digest-sha3-patched', '~> 1.1.1'
   spec.add_dependency 'base32', '~> 0.3'
   spec.add_dependency 'faraday', '~> 0.11'
   spec.add_dependency 'faraday_middleware', '~> 0.11'


### PR DESCRIPTION
依存先のgem ( `digest-sha3-1.1.0` ) に問題があるようで、問題修正済みのものが別のgemとして公開されているので、そちらに依存先を差し替えています。

元のgemで同様の問題がissueに出てPRも出ているものの、マージされないままになっているようです。

https://github.com/phusion/digest-sha3-ruby/pull/8

https://wiki.ubuntu.com/ToolChain/CompilerFlags#A-Wformat_-Wformat-security

パッチ済みのgem

https://rubygems.org/gems/digest-sha3-patched

以下 gem install しようとしたときに出たエラーメッセージ
```
$ sudo gem install nem-ruby  
Building native extensions. This could take a while...
ERROR:  Error installing nem-ruby:
	ERROR: Failed to build gem native extension.

    current directory: /var/lib/gems/2.5.0/gems/digest-sha3-1.1.0/ext/digest
/usr/bin/ruby2.5 -r ./siteconf20190211-5806-c2wbuk.rb extconf.rb
checking for ruby/digest.h... yes
checking for rb_str_set_len()... yes
creating Makefile

current directory: /var/lib/gems/2.5.0/gems/digest-sha3-1.1.0/ext/digest
make "DESTDIR=" clean

current directory: /var/lib/gems/2.5.0/gems/digest-sha3-1.1.0/ext/digest
make "DESTDIR="
compiling KeccakF-1600-reference.c
compiling KeccakNISTInterface.c
compiling KeccakSponge.c
compiling displayIntermediateValues.c
displayIntermediateValues.c: In function 'displayText':
displayIntermediateValues.c:113:9: error: format not a string literal and no format arguments [-Werror=format-security]
         fprintf(intermediateValueFile, text);
         ^~~~~~~
cc1: some warnings being treated as errors
Makefile:242: recipe for target 'displayIntermediateValues.o' failed
make: *** [displayIntermediateValues.o] Error 1

make failed, exit code 2

Gem files will remain installed in /var/lib/gems/2.5.0/gems/digest-sha3-1.1.0 for inspection.
Results logged to /var/lib/gems/2.5.0/extensions/x86_64-linux/2.5.0/digest-sha3-1.1.0/gem_make.out
```